### PR TITLE
bugfix to error: Class 'WhereIterable' has no instance method '[]'

### DIFF
--- a/lib/plugins/row_selection_model.dart
+++ b/lib/plugins/row_selection_model.dart
@@ -172,7 +172,7 @@ class RowSelectionModel extends SelectionModel {
       selection.add(cell.row);
       _grid.setActiveCell(cell.row, cell.cell);
     } else if (idx != -1 && (e.causedBy.ctrlKey || e.causedBy.metaKey)) {
-      selection = selection.where((o) => o != cell.row);
+      selection = selection.where((o) => o != cell.row).toList();
       _grid.setActiveCell(cell.row, cell.cell);
     } else if (selection.length > 0 && e.causedBy.shiftKey) {
       var last = selection.removeLast();


### PR DESCRIPTION
Hi Gunter

In Dartium console I intermittenly get errors in grids that use RowSelectionModel.

    'WhereIterable' has no instance method '[]'
